### PR TITLE
Add doom-molokai back to supported themes

### DIFF
--- a/core/core-themes-support.el
+++ b/core/core-themes-support.el
@@ -188,6 +188,7 @@
     (doom-laserwave                   . doom-themes)
     (doom-manegarm                    . doom-themes)
     (doom-material                    . doom-themes)
+    (doom-molokai                     . doom-themes)
     (doom-monokai-classic             . doom-themes)
     (doom-moonlight                   . doom-themes)
     (doom-nord                        . doom-themes)


### PR DESCRIPTION
----

# 

Theme got restore upstream. Make available in spacemacs again